### PR TITLE
Fix: Update actions/deploy-pages to v4 to resolve deployment errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2 
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated the GitHub Pages deployment workflow to use actions/deploy-pages@v4 instead of v2. This resolved an issue where the deploy job was failing with 'Cannot find any run with github.run_id' and a 404 error, despite the build job succeeding and uploading the artifact correctly.